### PR TITLE
Windows fixes

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,5 +1,5 @@
 ARG_ENABLE("uv", "for uv support", "no");
-ARG_ENABLE("httpparser", "for httpparser support", "yes");
+ARG_ENABLE("uv-httpparser", "for httpparser support in the uv extension", "yes");
 
 if (PHP_UV != "no") {
     var libuv_target_dir = ".\\libuv\\Release";
@@ -7,11 +7,11 @@ if (PHP_UV != "no") {
       libuv_target_dir = ".\\libuv\\Debug"
     }
 
-    if (CHECK_HEADER_ADD_INCLUDE("uv.h", "CFLAGS_UV", ".\\libuv\\include") && 
-        CHECK_LIB("uv.lib", "uv", libuv_target_dir)
+    if (CHECK_HEADER_ADD_INCLUDE("uv.h", "CFLAGS_UV", PHP_EXTRA_INCLUDES + ';' + configure_module_dirname + "\\libuv\\include") &&
+        CHECK_LIB("uv.lib;libuv.lib", "uv", PHP_EXTRA_LIBS + ';' + libuv_target_dir)
     ) {
-        if (PHP_HTTPPARSER == "yes") {
-            CHECK_HEADER_ADD_INCLUDE("http_parser.h", "CFLAGS_UV", ".\\http-parser")
+        if (PHP_UV_HTTPPARSER == "yes") {
+            CHECK_HEADER_ADD_INCLUDE("http_parser.h", "CFLAGS_UV", configure_module_dirname + "\\http-parser")
             ADD_SOURCES(configure_module_dirname + ".\\http-parser", "http_parser.c", "uv")
             EXTENSION('uv', 'php_uv.c uv.c');
         } else {
@@ -24,4 +24,6 @@ if (PHP_UV != "no") {
     CHECK_LIB("Iphlpapi.lib","uv", PHP_UV);
     CHECK_LIB("psapi.lib","uv", PHP_UV);
     CHECK_LIB("Ws2_32.lib","uv", PHP_UV);
+
+    ADD_EXTENSION_DEP('uv', 'sockets', false);
 }

--- a/config.w32
+++ b/config.w32
@@ -1,3 +1,6 @@
+
+// vim:ft=javascript
+
 ARG_ENABLE("uv", "for uv support", "no");
 ARG_ENABLE("uv-httpparser", "for httpparser support in the uv extension", "yes");
 
@@ -25,5 +28,9 @@ if (PHP_UV != "no") {
     CHECK_LIB("psapi.lib","uv", PHP_UV);
     CHECK_LIB("Ws2_32.lib","uv", PHP_UV);
 
-    ADD_EXTENSION_DEP('uv', 'sockets', false);
+    if (PHP_SOCKETS != "no") {
+        ADD_EXTENSION_DEP('uv', 'sockets', false);
+    } else {
+        ERROR('uv depends on the sockets extension');
+    }
 }

--- a/php_uv.c
+++ b/php_uv.c
@@ -4776,11 +4776,11 @@ PHP_FUNCTION(uv_stdio_new)
 
 static void php_ares_gethostbyname_cb( void *arg, int status, int timeouts, struct hostent *hostent)
 {
-	TSRMLS_FETCH();
 	zval *retval_ptr, *hostname, *addresses = NULL;
 	zval **params[2];
 	php_uv_ares_t *uv = (php_uv_ares_t*)arg;
 	struct in_addr **ptr;
+	TSRMLS_FETCH();
 
 	MAKE_STD_ZVAL(hostname);
 	ZVAL_STRING(hostname, hostent->h_name, 1);
@@ -6638,8 +6638,8 @@ PHP_MINFO_FUNCTION(uv)
 	php_info_print_table_start();
 	php_info_print_table_header(2,"libuv Support",  "enabled");
 	php_info_print_table_row(2,"Version", PHP_UV_EXTVER);
-	php_info_print_table_row(2,"bundled libuv Version", uv_version);
-	php_info_print_table_row(2,"bundled http-parser Version", http_parser_version);
+	php_info_print_table_row(2,"libuv Version", uv_version);
+	php_info_print_table_row(2,"http-parser Version", http_parser_version);
 	php_info_print_table_end();
 }
 


### PR DESCRIPTION
- extended config.w32 to look for libs/includes in extra dirs
- fixed config.w32 to care about the sockets ext
- --enable-uv-httpparser is a better wording
- since non bundled library can be used, wording fixed in minfo
- fixed build
