### PR TITLE
Add UV::S_IFDIR + UV::S_IFREG constants

### DIFF
--- a/php_uv.h
+++ b/php_uv.h
@@ -220,6 +220,20 @@ typedef struct {
 #define PHP_UV_LIST_INSERT(type, handle) zend_list_insert(type, handle)
 #endif
 
+
+/* File/directory stat mode constants*/
+#ifdef PHP_WIN32
+#define S_IFDIR _S_IFDIR
+#define S_IFREG _S_IFREG
+#else
+#ifndef S_IFDIR
+#define S_IFDIR 0040000
+#endif
+#ifndef S_IFREG
+#define S_IFREG 0100000
+#endif
+#endif
+
 /* TODO: remove these macro when libuv provides uv_inet_ntop & uv_inet_pton */
 #ifdef PHP_WIN32
 # include "libuv/src/ares/inet_net_pton.h"

--- a/uv.c
+++ b/uv.c
@@ -51,6 +51,9 @@ static int php_uv_class_init(TSRMLS_D)
 	zend_declare_class_constant_long(uv_class_entry, "O_TRUNC",   sizeof("O_TRUNC")-1,  O_TRUNC TSRMLS_CC);
 	zend_declare_class_constant_long(uv_class_entry, "O_APPEND",  sizeof("O_APPEND")-1, O_APPEND TSRMLS_CC);
 
+	zend_declare_class_constant_long(uv_class_entry, "S_IFDIR",  sizeof("S_IFDIR")-1, S_IFDIR TSRMLS_CC);
+	zend_declare_class_constant_long(uv_class_entry, "S_IFREG",  sizeof("S_IFREG")-1, S_IFREG TSRMLS_CC);
+
 #ifndef PHP_WIN32
 	zend_declare_class_constant_long(uv_class_entry, "O_NOCTTY",  sizeof("O_NOCTTY")-1, O_NOCTTY TSRMLS_CC);
 


### PR DESCRIPTION
This PR adds two new constants:
- `UV::S_IFDIR`
- `UV::S_IFREG`

These constants allow differentiation between regular files (S_IFREG) and directories (S_IFDIR) when used for bitwise AND operations against the `"mode"` value returned from `uv_fs_stat/fstat/lstat()`.

Example:

``` php
<?php
uv_fs_open(uv_default_loop(), __FILE__, UV::O_RDONLY, 0, function($r){
    uv_fs_fstat(uv_default_loop(), $r, function($result, $da) {
        echo "is directory: ", ($da['mode'] & UV::S_IFDIR ? 'yes' : 'no'), "\n";
        echo "is file: ", ($da['mode'] & UV::S_IFREG ? 'yes' : 'no'), "\n";
    });
});
uv_run();
```
