### PR TITLE
Add uv_fs_read() $offset param allowing seeking on open handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2180,7 +2180,7 @@ uv_run();
 
 
 
-### void uv_fs_read(resource $loop, zval $fd, long $length, callable $callback)
+### void uv_fs_read(resource $loop, zval $fd, long $offset, long $length, callable $callback)
 
 ##### *Description*
 
@@ -2191,6 +2191,10 @@ async read.
 *resource $loop*: uv loop handle
 
 *zval $fd*: this expects long $fd, resource $php_stream or resource $php_socket.
+
+*long $offset*: the offset position in the file at which reading should commence.
+
+*long $length*: the length in bytes that should be read starting at position *$offset*.
 
 *resource $callback*: this callback parameter expects (zval $fd, long $nread, string $buffer).
 

--- a/php_uv.c
+++ b/php_uv.c
@@ -950,12 +950,13 @@ static void php_uv_fs_common(uv_fs_type fs_type, INTERNAL_FUNCTION_PARAMETERS)
 			zval *zstream = NULL;
 			unsigned long fd;
 			unsigned long length;
-			
-			PHP_UV_FS_PARSE_PARAMETERS("zzlf", &zloop, &zstream, &length, &fci, &fcc);
+			unsigned long offset;
+
+			PHP_UV_FS_PARSE_PARAMETERS("zzllf", &zloop, &zstream, &offset, &length, &fci, &fcc);
 			memset(uv_fs_read_buf, 0, length);
 			PHP_UV_FS_SETUP()
 			PHP_UV_ZVAL_TO_FD(fd, zstream);
-			PHP_UV_FS_ASYNC(loop, read, fd, uv_fs_read_buf, length, -1);
+			PHP_UV_FS_ASYNC(loop, read, fd, uv_fs_read_buf, length, offset);
 			break;
 		}
 		case UV_FS_SENDFILE:
@@ -3023,6 +3024,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_uv_fs_read, 0, 0, 3)
 	ZEND_ARG_INFO(0, loop)
 	ZEND_ARG_INFO(0, fd)
+	ZEND_ARG_INFO(0, offset)
 	ZEND_ARG_INFO(0, size)
 	ZEND_ARG_INFO(0, callback)
 ZEND_END_ARG_INFO()
@@ -5713,7 +5715,7 @@ PHP_FUNCTION(uv_fs_open)
 /* }}} */
 
 
-/* {{{ proto void uv_fs_read(resoruce $loop, zval $fd, callable $callback)
+/* {{{ proto void uv_fs_read(resoruce $loop, zval $fd, long $offset, long $length, callable $callback)
 */
 PHP_FUNCTION(uv_fs_read)
 {

--- a/tests/300-fs.phpt
+++ b/tests/300-fs.phpt
@@ -5,7 +5,7 @@ Check for fs read and close
 define("FIXTURE_PATH", dirname(__FILE__) . "/fixtures/hello.data");
 
 uv_fs_open(uv_default_loop(),FIXTURE_PATH, UV::O_RDONLY, 0, function($r){
-    uv_fs_read(uv_default_loop(),$r,32,function($stream, $nread, $data) {
+    uv_fs_read(uv_default_loop(),$r, $offset=0, $len=32,function($stream, $nread, $data) {
         if ($nread <= 0) {
             if ($nread < 0) {
                 throw new Exception("read error");


### PR DESCRIPTION
This PR modifies `uv_fs_read()` with a new `long $offset` parameter. This allows the same file handle to be reused for multiple reads. Previously the only way to access a section of a file that had already been read was to open a new handle.

**Old:**

``` c
uv_fs_read(resource $loop, zval $fd, long $length, callable $callback)
```

**New:**

``` c
uv_fs_read(resource $loop, zval $fd, long $offset, long $length, callable $callback)
```

This change represents a minor BC break for existing code using `uv_fs_read()`.
